### PR TITLE
Fix rooterLink error #9

### DIFF
--- a/src/app/hero-search/hero-search.component.html
+++ b/src/app/hero-search/hero-search.component.html
@@ -4,7 +4,7 @@
 
   <ul class="search-result">
     <li *ngFor="let hero of heroes$ | async" >
-      <a routerLink="/detail/{{hero.id}}">
+      <a href="/detail/{{hero.id}}">
         {{hero.name}}
       </a>
     </li>


### PR DESCRIPTION
Change rooterLink attribute to href
- a tag doesn't have rooterLink, so I changed href
- As a result of the manual operation check, there is no problem